### PR TITLE
fix: ordered elements and attributes to make file content deterministic

### DIFF
--- a/lib/puppet/parser/functions/hash_to_xml.rb
+++ b/lib/puppet/parser/functions/hash_to_xml.rb
@@ -1,5 +1,40 @@
 require 'xmlsimple'
 
+def fix_element element
+
+    if element.has_attributes?
+        sorted_attrs = element.attributes.sort_by { |x| x[0] }
+
+        element.attributes.each do |a|
+            element.delete_attribute a[0]
+        end
+
+        sorted_attrs.each do |a|
+            element.add_attribute(a[0],a[1])
+        end
+    end
+
+    if element.has_elements?
+        sorted_child_elements = element.elements.sort_by { |x| x.xpath }
+
+        element.elements.each do |e|
+            element.delete_element e
+        end
+
+        sorted_child_elements.each do |e|
+            element.add_element e
+            fix_element e
+        end
+    end
+end
+
+def fix_xml xml
+    out = ""
+    fix_element xml.elements.first
+    xml.write(out,4)
+    out
+end
+
 Puppet::Parser::Functions.newfunction(:hash_to_xml, :type => :rvalue, :doc =>
   "Function that converts a hash to an XML string") do |args|
   if args.length < 1 or args.length > 2
@@ -13,8 +48,10 @@ Puppet::Parser::Functions.newfunction(:hash_to_xml, :type => :rvalue, :doc =>
   end
 
   if args.length == 1
-    XmlSimple.xml_out(args[0])
+    x = REXML::Document.new XmlSimple.xml_out(args[0])
   else
-    XmlSimple.xml_out(args[0],args[1])
+    x = REXML::Document.new XmlSimple.xml_out(args[0],args[1])
   end
+
+  fix_xml(x)
 end


### PR DESCRIPTION
Hi!

This fix helps us to make generated files deterministic, otherwise the order of attributes and elements changes each time puppet master is restarted or there are some changes in libs, it leads to puppet changes  in the config files and service restarts, although nothing has changed in fact

For us this is a workaround, may be you have a better suggestion... 
